### PR TITLE
Update API to support OpenSSL v3 while keeping support for older API

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -3,8 +3,10 @@ use warnings;
 
 use 5.006;
 use ExtUtils::MakeMaker 6.48;
-use Crypt::OpenSSL::Guess qw(openssl_inc_paths openssl_lib_paths);
+use Crypt::OpenSSL::Guess qw(openssl_inc_paths openssl_lib_paths openssl_version);
 
+my ($major, $minor, $patch) = openssl_version(); 
+print "OpenSSL version: $major.$minor $patch", "\n";
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
 

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,6 +1,7 @@
 use strict;
 use warnings;
 use Config;
+use List::Util 1.45           qw(uniq);
 
 use 5.006;
 use ExtUtils::MakeMaker 6.48;
@@ -10,6 +11,24 @@ my ($major, $minor, $patch) = openssl_version();
 print "OpenSSL version: $major.$minor $patch", "\n";
 # See lib/ExtUtils/MakeMaker.pm for details of how to influence
 # the contents of the Makefile that is written.
+
+my $libs = ' -lssl -lcrypto';
+if ( $Config{osname} eq 'aix' ) {
+    $libs = $libs . ' -lz';
+}
+
+my $ssllibpth = openssl_lib_paths();
+my $lddlflags = $Config{lddlflags};
+$lddlflags    =~ s/(?=-L)/$ssllibpth /;
+
+my $ldflags = $Config{ldflags};
+$ldflags    =~ s/(?=-L)/$ssllibpth /;
+
+if ($^O eq "hpux" && $Config{ld} eq "/usr/bin/ld") {
+    my $bpth = join ":" => uniq (+("$ssllibpth $lddlflags $ldflags") =~ m/-L(\S+)/g);
+    $lddlflags .= " +b $bpth";
+    $ldflags   .= " +Wl,+b,$bpth";
+}
 
 WriteMakefile(
     'NAME'             => 'Crypt::OpenSSL::RSA',
@@ -25,8 +44,9 @@ WriteMakefile(
         'Test::More'             => 0,
     },
     'OBJECT' => 'RSA.o',
-    'LIBS'   => [openssl_lib_paths() . ' -lssl -lcrypto'],
-    'LDDLFLAGS' => openssl_lib_paths() . ' ' . $Config{lddlflags},
+    'LIBS'             => [ openssl_lib_paths() . $libs ],
+    'LDDLFLAGS'        => $lddlflags,
+    'LDFLAGS'          => $ldflags,
     'DEFINE' => '-DPERL5 -DOPENSSL_NO_KRB5',
 
     # perl-5.8/gcc-3.2 needs -DPERL5, and redhat9 likes -DOPENSSL_NO_KRB5

--- a/Makefile.PL
+++ b/Makefile.PL
@@ -1,5 +1,6 @@
 use strict;
 use warnings;
+use Config;
 
 use 5.006;
 use ExtUtils::MakeMaker 6.48;
@@ -25,6 +26,7 @@ WriteMakefile(
     },
     'OBJECT' => 'RSA.o',
     'LIBS'   => [openssl_lib_paths() . ' -lssl -lcrypto'],
+    'LDDLFLAGS' => openssl_lib_paths() . ' ' . $Config{lddlflags},
     'DEFINE' => '-DPERL5 -DOPENSSL_NO_KRB5',
 
     # perl-5.8/gcc-3.2 needs -DPERL5, and redhat9 likes -DOPENSSL_NO_KRB5

--- a/RSA.xs
+++ b/RSA.xs
@@ -184,7 +184,6 @@ unsigned char* get_message_digest(SV* text_SV, int hash_method)
     unsigned char* text;
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     unsigned char *md;
-    size_t *mdlen;
     CHECK_NEW(md, get_digest_length(hash_method), unsigned char);
 #endif
     text = (unsigned char*) SvPV(text_SV, text_length);

--- a/RSA.xs
+++ b/RSA.xs
@@ -69,6 +69,7 @@ void croakSsl(char* p_file, int p_line)
 char _is_private(rsaData* p_rsa)
 {
 #if OLD_CRUFTY_SSL_VERSION
+    const BIGNUM* d;
     d = p_rsa->rsa->d;
 #else
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L

--- a/RSA.xs
+++ b/RSA.xs
@@ -557,14 +557,14 @@ generate_key(proto, bitsSV, exponent = 65537)
     BN_set_word(e, exponent);
 #if OPENSSL_VERSION_NUMBER < 0x00908000L
     rsa = RSA_generate_key(SvIV(bitsSV), exponent, NULL, NULL);
-    CHECK_OPEN_SSL(rsa != -1);
+    CHECK_OPEN_SSL(rsa != NULL);
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x00908000L && OPENSSL_VERSION_NUMBER < 0x30000000L
     int rc;
     rsa = RSA_new();
     rc = RSA_generate_key_ex(rsa, SvIV(bitsSV), e, NULL);
-￼   BN_free(e);
-    CHECK_OPEN_SSL(rsa != -1);
+    BN_free(e);
+    CHECK_OPEN_SSL(rsa != NULL);
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);

--- a/RSA.xs
+++ b/RSA.xs
@@ -709,8 +709,6 @@ _new_key_from_parameters(proto, n, e, d, p, q)
 
         int status = EVP_PKEY_fromdata(pctx, &rsa, EVP_PKEY_KEYPAIR, params);
         THROW( status > 0 && rsa != NULL );
-        //EVP_PKEY_CTX* test_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, rsa, NULL);
-        //THROW(EVP_PKEY_check(test_ctx) == 1);
 #else
         CHECK_OPEN_SSL(RSA_set0_key(rsa, n, e, d));
 #endif

--- a/RSA.xs
+++ b/RSA.xs
@@ -186,6 +186,7 @@ unsigned char* get_message_digest(SV* text_SV, int hash_method)
     CHECK_NEW(md, get_digest_length(hash_method), unsigned char);
 #endif
     text = (unsigned char*) SvPV(text_SV, text_length);
+
     switch(hash_method)
     {
         case NID_md5:
@@ -711,6 +712,8 @@ _new_key_from_parameters(proto, n, e, d, p, q)
         rsa->d = d;
 #else
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+        if(d != NULL)
+            THROW(OSSL_PARAM_BLD_push_BN(params_build, OSSL_PKEY_PARAM_RSA_D, d));
         params = OSSL_PARAM_BLD_to_param(params_build);
         THROW(params != NULL);
 

--- a/RSA.xs
+++ b/RSA.xs
@@ -539,14 +539,21 @@ generate_key(proto, bitsSV, exponent = 65537)
 #endif
   CODE:
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    BIGNUM *e;
+    e = BN_new();
+    BN_set_word(e, exponent);
+
     ctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
 
     CHECK_OPEN_SSL(ctx);
     CHECK_OPEN_SSL(EVP_PKEY_keygen_init(ctx) == 1);
     CHECK_OPEN_SSL(EVP_PKEY_CTX_set_rsa_keygen_bits(ctx, SvIV(bitsSV)) > 0);
+    CHECK_OPEN_SSL(EVP_PKEY_CTX_set1_rsa_keygen_pubexp(ctx, e) >0);
     CHECK_OPEN_SSL(EVP_PKEY_generate(ctx, &rsa) == 1);
     CHECK_OPEN_SSL(rsa != NULL);
 
+    e = NULL;
+    BN_free(e);
     EVP_PKEY_CTX_free(ctx);
 #else
     rsa = RSA_generate_key(SvIV(bitsSV), exponent, NULL, NULL);

--- a/RSA.xs
+++ b/RSA.xs
@@ -82,10 +82,11 @@ char _is_private(rsaData* p_rsa)
 #endif
     return(d != NULL);
 }
-
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+
 SV* make_rsa_obj(SV* p_proto, EVP_PKEY* p_rsa)
 #else
+
 SV* make_rsa_obj(SV* p_proto, RSA* p_rsa)
 #endif
 {
@@ -137,8 +138,8 @@ int get_digest_length(int hash_method)
             break;
     }
 }
-
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+
 EVP_MD *get_md_bynid(int hash_method)
 {
     switch(hash_method)
@@ -262,13 +263,14 @@ int get_key_size(rsaData* p_rsa) {
 #endif
     return size;
 }
-
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+
 EVP_PKEY* _load_rsa_key(SV* p_keyStringSv,
                         EVP_PKEY*(*p_loader)(BIO *, EVP_PKEY**, pem_password_cb*, void*),
                    SV* p_passphaseSv)
 
 #else
+
 RSA* _load_rsa_key(SV* p_keyStringSv,
                    RSA*(*p_loader)(BIO*, RSA**, pem_password_cb*, void*),
                    SV* p_passphaseSv)
@@ -300,11 +302,12 @@ RSA* _load_rsa_key(SV* p_keyStringSv,
     CHECK_OPEN_SSL(rsa);
     return rsa;
 }
-
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+
 SV* rsa_crypt(rsaData* p_rsa, SV* p_from,
               int (*p_crypt)(EVP_PKEY_CTX*, unsigned char*, size_t*, const unsigned char*, size_t), int enc)
 #else
+
 SV* rsa_crypt(rsaData* p_rsa, SV* p_from,
               int (*p_crypt)(int, const unsigned char*, unsigned char*, RSA*, int))
 #endif
@@ -952,6 +955,7 @@ use_sha512_hash(p_rsa)
     rsaData* p_rsa;
   CODE:
     p_rsa->hashMode =  NID_sha512;
+
 #endif
 
 void

--- a/RSA.xs
+++ b/RSA.xs
@@ -593,6 +593,7 @@ _new_key_from_parameters(proto, n, e, d, p, q)
         croak("At least a modulus and public key must be provided");
     }
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+    OSSL_PARAM *params = NULL;
     EVP_PKEY_CTX *pctx = EVP_PKEY_CTX_new_from_name(NULL, "RSA", NULL);
     CHECK_OPEN_SSL(pctx != NULL);
     CHECK_OPEN_SSL(EVP_PKEY_fromdata_init(pctx) > 0);
@@ -669,7 +670,6 @@ _new_key_from_parameters(proto, n, e, d, p, q)
         THROW(OSSL_PARAM_BLD_push_BN(params_build, OSSL_PKEY_PARAM_RSA_EXPONENT2, dmq1));
         THROW(OSSL_PARAM_BLD_push_BN(params_build, OSSL_PKEY_PARAM_RSA_COEFFICIENT1, iqmp));
 
-        OSSL_PARAM *params = NULL;
         params = OSSL_PARAM_BLD_to_param(params_build);
         THROW(params != NULL);
 
@@ -711,6 +711,13 @@ _new_key_from_parameters(proto, n, e, d, p, q)
         rsa->d = d;
 #else
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
+        params = OSSL_PARAM_BLD_to_param(params_build);
+        THROW(params != NULL);
+
+        int status = EVP_PKEY_fromdata(pctx, &rsa, EVP_PKEY_KEYPAIR, params);
+        THROW( status > 0 && rsa != NULL );
+        //EVP_PKEY_CTX* test_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, rsa, NULL);
+        //THROW(EVP_PKEY_check(test_ctx) == 1);
 #else
         CHECK_OPEN_SSL(RSA_set0_key(rsa, n, e, d));
 #endif

--- a/RSA.xs
+++ b/RSA.xs
@@ -176,8 +176,7 @@ unsigned char* get_message_digest(SV* text_SV, int hash_method)
     STRLEN text_length;
     unsigned char* text;
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    unsigned char *md;
-    CHECK_NEW(md, get_digest_length(hash_method), unsigned char);
+    static unsigned char md[EVP_MAX_MD_SIZE];
 #endif
     text = (unsigned char*) SvPV(text_SV, text_length);
 

--- a/RSA.xs
+++ b/RSA.xs
@@ -675,6 +675,8 @@ _new_key_from_parameters(proto, n, e, d, p, q)
 
         int status = EVP_PKEY_fromdata(pctx, &rsa, EVP_PKEY_KEYPAIR, params);
         THROW( status > 0 && rsa != NULL );
+        EVP_PKEY_CTX* test_ctx = EVP_PKEY_CTX_new_from_pkey(NULL, rsa, NULL);
+        THROW(EVP_PKEY_check(test_ctx) == 1);
 #else
         THROW(RSA_set0_crt_params(rsa, dmp1, dmq1, iqmp));
 #endif

--- a/RSA.xs
+++ b/RSA.xs
@@ -10,6 +10,9 @@
 #include <openssl/pem.h>
 #include <openssl/rand.h>
 #include <openssl/ripemd.h>
+#if OPENSSL_VERSION_NUMBER < 0x30000000
+#include <openssl/whrlpool.h>
+#endif
 #include <openssl/rsa.h>
 #include <openssl/sha.h>
 #include <openssl/ssl.h>

--- a/RSA.xs
+++ b/RSA.xs
@@ -681,22 +681,6 @@ _new_key_from_parameters(proto, n, e, d, p, q)
 #else
         THROW(RSA_check_key(rsa) == 1);
 #endif
-     err:
-        if (p_minus_1) BN_clear_free(p_minus_1);
-        if (q_minus_1) BN_clear_free(q_minus_1);
-        if (dmp1) BN_clear_free(dmp1);
-        if (dmq1) BN_clear_free(dmq1);
-        if (iqmp) BN_clear_free(iqmp);
-        if (ctx) BN_CTX_free(ctx);
-        if (error)
-        {
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-            EVP_PKEY_free(rsa);
-#else
-            RSA_free(rsa);
-#endif
-            CHECK_OPEN_SSL(0);
-        }
     }
     else
     {
@@ -716,8 +700,33 @@ _new_key_from_parameters(proto, n, e, d, p, q)
 #endif
 #endif
     }
+
     RETVAL = make_rsa_obj(aTHX_ proto, rsa);
-}
+    if(RETVAL)
+        goto end;
+
+    err:
+        //if (p) BN_clear_free(p);
+        if (p_minus_1) BN_clear_free(p_minus_1);
+        //if (q) BN_clear_free(q);
+        //if (d) BN_clear_free(d);
+        if (q_minus_1) BN_clear_free(q_minus_1);
+        if (dmp1) BN_clear_free(dmp1);
+        if (dmq1) BN_clear_free(dmq1);
+        if (iqmp) BN_clear_free(iqmp);
+        if (ctx) BN_CTX_free(ctx);
+        if (error)
+        {
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+            EVP_PKEY_free(rsa);
+#else
+            RSA_free(rsa);
+#endif
+            CHECK_OPEN_SSL(0);
+        }
+    }
+    end:
+
   OUTPUT:
     RETVAL
 

--- a/RSA.xs
+++ b/RSA.xs
@@ -20,6 +20,11 @@
 #include <openssl/encoder.h>
 #endif
 
+#if OPENSSL_VERSION_NUMBER >= 0x30000000L
+#define UNSIGNED_CHAR unsigned char
+#else
+#define UNSIGNED_CHAR char
+#endif
 typedef struct
 {
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
@@ -269,7 +274,7 @@ RSA* _load_rsa_key(SV* p_keyStringSv,
 {
     STRLEN keyStringLength;
     char* keyString;
-    char* passphase = NULL;
+    UNSIGNED_CHAR *passphase = NULL;
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     EVP_PKEY* rsa;
 #else
@@ -307,23 +312,18 @@ SV* rsa_crypt(rsaData* p_rsa, SV* p_from,
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     STRLEN from_length;
     size_t to_length;
-    unsigned char* to;
 #else
     STRLEN from_length;
     int to_length;
-    char* to;
 #endif
+    UNSIGNED_CHAR *to;
     int size;
     unsigned char* from;
     SV* sv;
 
     from = (unsigned char*) SvPV(p_from, from_length);
     size = get_key_size(p_rsa);
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    CHECK_NEW(to, size, unsigned char);
-#else
-    CHECK_NEW(to, size, char);
-#endif
+    CHECK_NEW(to, size, UNSIGNED_CHAR);
 #if OPENSSL_VERSION_NUMBER >= 0x30000000L
     EVP_PKEY_CTX *ctx;
 
@@ -427,11 +427,7 @@ get_private_key_string(p_rsa, passphase_SV=&PL_sv_undef, cipher_name_SV=&PL_sv_u
     SV* cipher_name_SV;
   PREINIT:
     BIO* stringBIO;
-#if OPENSSL_VERSION_NUMBER >= 0x30000000L
-    unsigned char* passphase = NULL;
-#else
-    char* passphase = NULL;
-#endif
+    char *passphase = NULL;
     STRLEN passphaseLength = 0;
     char* cipher_name;
     const EVP_CIPHER* enc = NULL;
@@ -440,7 +436,7 @@ get_private_key_string(p_rsa, passphase_SV=&PL_sv_undef, cipher_name_SV=&PL_sv_u
         croak("Passphrase is required for cipher");
     }
     if (SvPOK(passphase_SV)) {
-        passphase = (unsigned char *) SvPV(passphase_SV, passphaseLength);
+        passphase = SvPV(passphase_SV, passphaseLength);
         if (SvPOK(cipher_name_SV)) {
             cipher_name = SvPV_nolen(cipher_name_SV);
         }
@@ -460,7 +456,7 @@ get_private_key_string(p_rsa, passphase_SV=&PL_sv_undef, cipher_name_SV=&PL_sv_u
                              NULL, NULL);
 #else
     PEM_write_bio_RSAPrivateKey(
-        stringBIO, p_rsa->rsa, enc, passphase, passphaseLength, NULL, NULL);
+        stringBIO, p_rsa->rsa, enc, (unsigned char *) passphase, passphaseLength, NULL, NULL);
 #endif
     RETVAL = extractBioString(stringBIO);
 
@@ -530,9 +526,9 @@ generate_key(proto, bitsSV, exponent = 65537)
     CHECK_OPEN_SSL(rsa != NULL);
 #endif
 #if OPENSSL_VERSION_NUMBER >= 0x00908000L && OPENSSL_VERSION_NUMBER < 0x30000000L
-    int rc;
     rsa = RSA_new();
-    rc = RSA_generate_key_ex(rsa, SvIV(bitsSV), e, NULL);
+    if (!RSA_generate_key_ex(rsa, SvIV(bitsSV), e, NULL))
+       croak("Unable to generate a key");
     BN_free(e);
     CHECK_OPEN_SSL(rsa != NULL);
 #endif

--- a/RSA.xs
+++ b/RSA.xs
@@ -242,11 +242,13 @@ SV* cor_bn2sv(const BIGNUM* p_bn)
 SV* extractBioString(BIO* p_stringBio)
 {
     SV* sv;
-    BUF_MEM* bptr;
+    char *datap;
+    long datasize = 0;
 
     CHECK_OPEN_SSL(BIO_flush(p_stringBio) == 1);
-    BIO_get_mem_ptr(p_stringBio, &bptr);
-    sv = newSVpv(bptr->data, bptr->length);
+
+    datasize = BIO_get_mem_data(p_stringBio, &datap);
+    sv = newSVpv(datap, datasize);
 
     CHECK_OPEN_SSL(BIO_set_close(p_stringBio, BIO_CLOSE) == 1);
     BIO_free(p_stringBio);

--- a/t/rsa.t
+++ b/t/rsa.t
@@ -3,6 +3,7 @@ use Test::More;
 
 use Crypt::OpenSSL::Random;
 use Crypt::OpenSSL::RSA;
+use Crypt::OpenSSL::Guess qw(openssl_version);
 
 BEGIN { plan tests => 43 + ( UNIVERSAL::can( "Crypt::OpenSSL::RSA", "use_sha512_hash" ) ? 4 * 5 : 0 ) }
 
@@ -145,9 +146,16 @@ if ( UNIVERSAL::can( "Crypt::OpenSSL::RSA", "use_sha512_hash" ) ) {
     _Test_Sign_And_Verify( $plaintext, $rsa, $rsa_pub );
 }
 
-$rsa->use_ripemd160_hash();
-$rsa_pub->use_ripemd160_hash();
-_Test_Sign_And_Verify( $plaintext, $rsa, $rsa_pub );
+my ($major, $minor, $patch) = openssl_version();
+
+SKIP: {
+        skip "ripemd160 in legacy provider between 3.02 and 3.07", 5 if $major eq '3.0' &&
+            ($minor ge '2' && $minor le '6');
+
+        $rsa->use_ripemd160_hash();
+        $rsa_pub->use_ripemd160_hash();
+        _Test_Sign_And_Verify( $plaintext, $rsa, $rsa_pub );
+}
 
 if (UNIVERSAL::can("Crypt::OpenSSL::RSA", "use_whirlpool_hash")) {
     $rsa->use_whirlpool_hash();

--- a/t/rsa.t
+++ b/t/rsa.t
@@ -5,7 +5,9 @@ use Crypt::OpenSSL::Random;
 use Crypt::OpenSSL::RSA;
 use Crypt::OpenSSL::Guess qw(openssl_version);
 
-BEGIN { plan tests => 43 + ( UNIVERSAL::can( "Crypt::OpenSSL::RSA", "use_sha512_hash" ) ? 4 * 5 : 0 ) }
+BEGIN { plan tests => 43 +
+        ( UNIVERSAL::can( "Crypt::OpenSSL::RSA", "use_sha512_hash" ) ? 4 * 5 : 0 ) +
+        ( UNIVERSAL::can( "Crypt::OpenSSL::RSA", "use_whirlpool_hash" ) ? 1 * 5 : 0 ) }
 
 sub _Test_Encrypt_And_Decrypt {
     my ( $p_plaintext_length, $p_rsa, $p_check_private_encrypt ) = @_;


### PR DESCRIPTION
This is very much a work in progress and is more changes that I would like.  I suspect I can further reduce the changes as I clean up.  I would welcome assistance if anyone would like to send a pull request against https://github.com/timlegge/Crypt-OpenSSL-RSA/tree/openssl3-tim

ToDo:

- [x] More cleanups and fix the checks in the modules style
- [x] Fix the two remaining deprecated functions MD5 and RIPEMD160
- [x] Clean tests from the current github actions
- [x] Add additional OSs on the github actions
- [ ] Actually verify the OPENSSL Versions - Likely just go with OPENSSL_VERSION_NUMBER >= 0x30000000L
- [x] Figure out the remaining test failures
- [x] - bignum.t - older openssl seemed to fill in missing values when a key was generated from data values
- [x] - format - opensslv3 public key format is not PKCS1 format
- [ ] Performance testing
- [ ] Create some compatibility tests - test values generated by old API that can be validated on the new API
- [ ] other things

Issues:
1. Need to be able to verify that data generated by the old module can be reproduced/validated by the new version
2. Performance needs to be tested as openSSL 3 uses multiple calls to do things that the older version did.  I chose not to keet the EVP_PKEY_CTX around which might be a performance mistake (but easily rectified) and OpenSSL does talk about digests and their impact on performance so having some tests would likely help