### PR TITLE
Pss padding

### DIFF
--- a/RSA.pm
+++ b/RSA.pm
@@ -245,13 +245,9 @@ Encrypting user data directly with RSA is insecure.
 
 PKCS #1 v1.5 padding has been disabled as it is nearly impossible to use this
 padding method in a secure manner.  It is known to be vulnerable to timing
-based side channel attacks.
+based side channel attacks.  use_pkcs1_padding() results in a fatal error.
+
 L<Marvin Attack|https://github.com/tomato42/marvin-toolkit/blob/master/README.md>
-
-use_pkcs1_padding() now sets the padding method to use_pkcs1_pss_padding. 
-
-B<Note>: RSA-PSS cannot be used for encryption/decryption and results in a
-fatal error.  Call C<use_pkcs1_oaep_padding> for encryption operations. 
 
 =item use_pkcs1_oaep_padding
 
@@ -266,6 +262,9 @@ Use C<RSA-PSS> padding as defined in PKCS#1 v2.1.  In general, RSA-PSS
 should be used as a replacement for RSA-PKCS#1 v1.5.  The module specifies
 the message digest being requested and the appropriate mgf1 setting and
 salt length for the digest.
+
+B<Note>: RSA-PSS cannot be used for encryption/decryption and results in a
+fatal error.  Call C<use_pkcs1_oaep_padding> for encryption operations. 
 
 =item use_sslv23_padding
 

--- a/RSA.xs
+++ b/RSA.xs
@@ -931,7 +931,7 @@ void
 use_pkcs1_padding(p_rsa)
     rsaData* p_rsa;
   CODE:
-    p_rsa->padding = RSA_PKCS1_PSS_PADDING;
+    croak("PKCS#1 1.5 is disabled as it is known to be vulnerable to marvin attacks.");
 
 void
 use_pkcs1_oaep_padding(p_rsa)

--- a/t/rsa.t
+++ b/t/rsa.t
@@ -6,7 +6,7 @@ use Crypt::OpenSSL::RSA;
 use Crypt::OpenSSL::Guess qw(openssl_version);
 
 BEGIN {
-    plan tests => 97 + ( UNIVERSAL::can( "Crypt::OpenSSL::RSA", "use_sha512_hash" ) ? 4 * 5 : 0 ) + ( UNIVERSAL::can( "Crypt::OpenSSL::RSA", "use_whirlpool_hash" ) ? 1 * 5 : 0 );
+    plan tests => 67 + ( UNIVERSAL::can( "Crypt::OpenSSL::RSA", "use_sha512_hash" ) ? 4 * 5 : 0 ) + ( UNIVERSAL::can( "Crypt::OpenSSL::RSA", "use_whirlpool_hash" ) ? 1 * 5 : 0 );
 }
 
 sub _Test_Encrypt_And_Decrypt {
@@ -37,6 +37,7 @@ sub _Test_Sign_And_Verify {
     my $sig = eval { $rsa->sign($plaintext) };
   SKIP: {
         skip "OpenSSL error: illegal or unsupported padding mode - $hash", 5 if $@ =~ /illegal or unsupported padding mode/i;
+        skip "OpenSSL error: invalid digest - $hash", 5 if $@ =~ /invalid digest/i;
         ok( $rsa_pub->verify( $plaintext, $sig ), "rsa_pub verify $hash");
 
         my $false_sig = unpack "H*", $sig;
@@ -121,7 +122,7 @@ _check_for_croak(
 
 $plaintext .= $plaintext x 5;
 
-my @paddings = qw/pkcs1 pkcs1_oaep pkcs1_pss/;
+my @paddings = qw/pkcs1_oaep pkcs1_pss/;
 foreach my $padding (@paddings) {
   my $p = "use_$padding\_padding";
 


### PR DESCRIPTION
Add support for use_pkcs1_pss_padding
   
This change implements RSA_PKCS1_PSS_PADDING as the recommended replacement for RSA_PKCS1_PADDING
    
It should also be noted that RSA_PKCS1_PSS_PADDING (and use_pkcs1_pss_padding should only be used for signing/verification operations

Fatal error if RSA-PSS is used for encryption operations