### PR TITLE
Change the default hash mode to sha256

### DIFF
--- a/RSA.xs
+++ b/RSA.xs
@@ -114,7 +114,11 @@ SV* make_rsa_obj(SV* p_proto, EVP_PKEY* p_rsa)
 
     CHECK_NEW(rsa, 1, rsaData);
     rsa->rsa = p_rsa;
+#ifdef SHA512_DIGEST_LENGTH
+    rsa->hashMode = NID_sha256;
+#else
     rsa->hashMode = NID_sha1;
+#endif
     rsa->padding = RSA_PKCS1_OAEP_PADDING;
     return sv_bless(
         newRV_noinc(newSViv((IV) rsa)),


### PR DESCRIPTION
sha1 is problematic especially since RedHat disabled it's usage