### PR TITLE
Add dependabot

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"


### PR DESCRIPTION
It will send PRs when newer versions of github actions are released.

Once you accept this you'll get a PR as `actions/checkout` is now out of date. It has v6 but this repo is using v4.